### PR TITLE
[UI/#41] : 롤링 페이퍼 리스트 스켈레톤 ui 적용

### DIFF
--- a/src/components/Skeleton/DelayComponent.js
+++ b/src/components/Skeleton/DelayComponent.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useEffect, useState } from 'react';
+
+const DELAY_MS = 300;
+
+const DelayComponent = ({ children }) => {
+  const [isDelay, setIsDelay] = useState(false);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setIsDelay(true);
+    }, DELAY_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  if (!isDelay) return null;
+
+  return <>{children}</>;
+};
+
+export default DelayComponent;

--- a/src/components/Skeleton/PaperListSkeleton/PaperListSkeleton.jsx
+++ b/src/components/Skeleton/PaperListSkeleton/PaperListSkeleton.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import DelayComponent from '../DelayComponent';
+import * as S from './PaperListSkeleton.style';
+
+const PaperListSkeleton = () => {
+  return (
+    <DelayComponent>
+      <S.SkeletonContainer>
+        <S.SkeletonCard />
+        <S.SkeletonCard />
+        <S.SkeletonCard />
+        <S.SkeletonCard />
+      </S.SkeletonContainer>
+    </DelayComponent>
+  );
+};
+
+export default PaperListSkeleton;

--- a/src/components/Skeleton/PaperListSkeleton/PaperListSkeleton.style.js
+++ b/src/components/Skeleton/PaperListSkeleton/PaperListSkeleton.style.js
@@ -1,0 +1,75 @@
+import styled, { keyframes } from 'styled-components';
+import { COLORS } from '../../../style/colorPalette';
+
+const BREAKPOINT_TABLET = 768;
+const BREAKPOINT_PC = 1200;
+
+const onTablet = `@media only screen and (min-width: ${BREAKPOINT_TABLET}px) and (max-width: ${
+  BREAKPOINT_PC - 1
+}px)`;
+
+const onPc = `@media only screen and (min-width: ${BREAKPOINT_PC}px)`;
+
+export const SkeletonContainer = styled.div`
+  display: flex;
+  gap: 1.2rem;
+  width: 100%;
+  height: 24.8rem;
+  padding: 0 2rem;
+
+  ${onTablet} {
+    height: 26rem;
+  }
+
+  ${onPc} {
+    padding: 0 0.6rem;
+    margin: 0 1.4rem;
+    height: 26rem;
+  }
+`;
+
+const Loading = keyframes`
+  0% {
+    transform: translateX(-10rem);
+  }
+  70%,
+  100% {
+    transform: translateX(27rem);
+  }
+`;
+
+export const SkeletonCard = styled.div`
+  overflow: hidden;
+  position: relative;
+  width: 20.8rem;
+  height: 23.2rem;
+  border-radius: 1.6rem;
+  box-shadow: 0 0.2rem 1.2rem 0 rgba(0, 0, 0, 0.08);
+  background-color: ${COLORS.GRAY_200};
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0rem;
+    width: 10rem;
+    height: 100%;
+    background: linear-gradient(
+      to right,
+      ${COLORS.GRAY_200},
+      ${COLORS.GRAY_300},
+      ${COLORS.GRAY_200}
+    );
+    animation: ${Loading} 1.6s infinite linear;
+  }
+
+  ${onTablet} {
+    width: 27.5rem;
+    height: 26rem;
+  }
+
+  ${onPc} {
+    width: 27.5rem;
+    height: 26rem;
+  }
+`;

--- a/src/components/Skeleton/PaperListSkeleton/index.js
+++ b/src/components/Skeleton/PaperListSkeleton/index.js
@@ -1,0 +1,1 @@
+export { default } from './PaperListSkeleton';

--- a/src/pages/PaperListPage/PaperListPage.js
+++ b/src/pages/PaperListPage/PaperListPage.js
@@ -5,6 +5,7 @@ import useRequest from './useRequest';
 import { Link } from 'react-router-dom';
 import PaperCard from '../../components/PaperCard';
 import ArrowButton from '../../components/ArrowButton';
+import PaperListSkeleton from '../../components/Skeleton/PaperListSkeleton';
 
 const PaperListPage = () => {
   const { data: recentPaper, isLoading: isLoadingRecent } = useRequest({
@@ -60,7 +61,7 @@ function PaperSection({ title, papers, isLoading }) {
   );
 }
 
-function CardList({ papers }) {
+function CardList({ papers, isLoading }) {
   const [slideIndex, setSlideIndex] = useState(0);
 
   const slideLeft = () => {
@@ -71,6 +72,8 @@ function CardList({ papers }) {
     if (slideIndex - 1 >= papers?.results?.length - 4) return;
     setSlideIndex((prev) => prev + 1);
   };
+
+  if (isLoading) return <PaperListSkeleton />;
 
   return (
     <>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #41 


## 📝 작업 내용

> 스켈레톤 ui를 적용사켰습니다.


## 📸 스크린샷 

https://github.com/part2-11team/rolling-paper/assets/114905530/70716b2f-2fab-4b58-ae1c-0bbecd8da789


## 💬 리뷰 요구사항

> 4초 이하 로딩시간은 로딩 스피너를, 그 이상은 스켈레톤을 사용하는게 좋다고 합니다 .. ㅜㅜ 
> 나중에 페이퍼 리스트 카드의 개수가 많아지면 로딩 시간이 길어질 것을 감안하여 스켈레톤으로 작업하였습니다. 
> 로딩 스피너가 더 괜찮을지?, 스켈레톤으로 해도 시각적으로 크게 풀편하지 않은지?를 중점적으로 봐주시면 감사하겠습니다 !
