### PR TITLE
Fix/#52 post id background

### DIFF
--- a/src/components/MessageCardWrapper/MessageCardWrapper.jsx
+++ b/src/components/MessageCardWrapper/MessageCardWrapper.jsx
@@ -113,7 +113,7 @@ export const MessageCardWrapper = ({
     }
 
     if (data.length === 0) {
-      pageRef.current.scrollTop -= 30;
+      pageRef.current.scrollTop -= 90;
       setToastVisible(true);
       toastUpdate.current = true;
     }

--- a/src/pages/PostIDPage/PostIDPage.jsx
+++ b/src/pages/PostIDPage/PostIDPage.jsx
@@ -23,6 +23,7 @@ export default function PostIDPage() {
   const scrollWrapperRef = useRef(null);
   const [dataError, setDataError] = useState(null);
   const [toastVisible, setToastVisible] = useState(false);
+  const [visibleHeader, setVisibleHeader] = useState(true);
   const [scrollVisible, setScrollVisible] = useState(false);
   const [messageCardData, setMessageCardData] = useState([]);
   const [pageBackgroundLoad, setPageBackgroundLoad] = useState(true);
@@ -116,12 +117,22 @@ export default function PostIDPage() {
   useEffect(() => {
     const handleResize = () => {
       setScrollBarHeightPosition(pageRef, scrollWrapperRef);
+      if (window.innerWidth < 768) {
+        setVisibleHeader(false);
+      } else {
+        setVisibleHeader(true);
+      }
     };
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  useEffect(() => {
+    if (window.innerWidth < 768) {
+      setVisibleHeader(false);
+    }
+  }, []);
   return (
     <PostIDContext.Provider
       value={{
@@ -136,7 +147,7 @@ export default function PostIDPage() {
         </S.ErrorWrapper>
       ) : (
         <S.PageWrapper ref={pageRef} onScroll={updateScrollbarPosition}>
-          <Header page="post" />
+          {visibleHeader && <Header page="post" />}
 
           <SubHeader value={{ userID, messageCardData }} />
           <Toast

--- a/src/pages/PostIDPage/PostIDPage.jsx
+++ b/src/pages/PostIDPage/PostIDPage.jsx
@@ -30,7 +30,7 @@ export default function PostIDPage() {
   const [currentCardData, setCurrentCardData] = useState({ id: null });
   const [userData, setUserData] = useState({
     name: null,
-    backgroundColor: 'beige',
+    backgroundColor: '#eeeeee',
     backgroundImageURL: null,
     recentMessages: [],
   });

--- a/src/pages/PostIDPage/PostIDPage.jsx
+++ b/src/pages/PostIDPage/PostIDPage.jsx
@@ -22,7 +22,6 @@ export default function PostIDPage() {
   const toastUpdate = useRef(false);
   const scrollWrapperRef = useRef(null);
   const [dataError, setDataError] = useState(null);
-  const [messageCount, setMessageCount] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
   const [scrollVisible, setScrollVisible] = useState(false);
   const [messageCardData, setMessageCardData] = useState([]);
@@ -52,14 +51,8 @@ export default function PostIDPage() {
 
   //update userdata for header, background image
   const getUserData = async (userID) => {
-    const {
-      name,
-      backgroundColor,
-      backgroundImageURL,
-      messageCount: messageCountData,
-      recentMessages,
-      error,
-    } = await getRecipientData(userID);
+    const { name, backgroundColor, backgroundImageURL, recentMessages, error } =
+      await getRecipientData(userID);
 
     if (error) {
       setDataError(error);
@@ -67,7 +60,6 @@ export default function PostIDPage() {
     }
 
     setUserData({ name, backgroundColor, backgroundImageURL, recentMessages });
-    setMessageCount(messageCountData);
     const img = new Image();
     img.src = backgroundImageURL;
     img.onload = () => {

--- a/src/pages/PostIDPage/PostIDPage.style.js
+++ b/src/pages/PostIDPage/PostIDPage.style.js
@@ -35,7 +35,7 @@ export const MessageWrapper = styled.div`
   width: 100%;
   height: fit-content;
   ${({ $url, $color, $load }) =>
-    $load
+    $load && $url
       ? `background-color: ${COLORS.GRAY_300}`
       : $url
       ? `background: url(${$url}) no-repeat center rgba(0, 0, 0, 0.5);`


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #52 



## 📝 작업 내용
- postID 페이지 단색 배경 적용 오류 수정
- postID 페이지 사용하지 않는 상태 CountMessage 삭제
- postID 페이지 모바일 버전 크기(너비 768px 미만)에서 헤더 사라지도록 변경


## 📸 스크린샷 
![image](https://github.com/part2-11team/rolling-paper/assets/89967066/3997f0c8-05ed-491a-89e9-1eb7affa5c75)
![image](https://github.com/part2-11team/rolling-paper/assets/89967066/ef33b024-41de-48e3-a496-cdda2e06e53c)


## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
