### PR TITLE
[FIX/#54] list 페이지 헤더 추가 및 warning 해결

### DIFF
--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -42,7 +42,7 @@ const MainPage = () => {
             </S.ImgBox>
           </S.ImgContainer>
         </S.Section>
-        <S.Section flexdirection="row-reverse">
+        <S.Section direction="row-reverse">
           <S.DescriptionDiv>
             <S.PointDiv>Point. 02</S.PointDiv>
             <S.MainH1>

--- a/src/pages/MainPage/MainPage.style.js
+++ b/src/pages/MainPage/MainPage.style.js
@@ -163,8 +163,7 @@ export const Section = styled.section`
     padding: 6rem 6rem;
     width: 100%;
     max-width: 114rem;
-    flex-direction: ${(props) =>
-      props.flexdirection ? props.flexdirection : 'row'};
+    flex-direction: ${(props) => (props.direction ? props.direction : 'row')};
     gap: 10rem;
     justify-content: left;
   }

--- a/src/pages/PaperListPage/PaperListPage.js
+++ b/src/pages/PaperListPage/PaperListPage.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import PaperCard from '../../components/PaperCard';
 import ArrowButton from '../../components/ArrowButton';
 import PaperListSkeleton from '../../components/Skeleton/PaperListSkeleton';
+import Header from '../../components/Common/Header/Header';
 
 const PaperListPage = () => {
   const { data: recentPaper, isLoading: isLoadingRecent } = useRequest({
@@ -27,6 +28,7 @@ const PaperListPage = () => {
 
   return (
     <>
+      <Header page="main" />
       <S.Container>
         <PaperSection
           title="인기 롤링 페이퍼 🔥"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #54 


## 📝 작업 내용

> list 페이지 헤더 추가 및 warning 해결


## 📸 스크린샷 
### warning 해결
![스크린샷 2024-03-06 오후 5 44 30](https://github.com/part2-11team/rolling-paper/assets/114905530/4150c569-f29d-44ed-ab0b-a12dd19d4ce2)

### 헤더 추가
![스크린샷 2024-03-06 오후 5 44 46](https://github.com/part2-11team/rolling-paper/assets/114905530/8a903c64-7a34-4ac7-ab1c-6ccf922c2d62)

## 💬 리뷰 요구사항

> $표시로 해결을 할려했는데 해결이 안되서 props 이름을 flexdirection -> direction으로 바꾸었습니다
