### PR TITLE
[MOD/#56] 포스트 메세지 페이지 헤더 수정 및 폰트 값 변경

### DIFF
--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -42,7 +42,7 @@ const MainPage = () => {
             </S.ImgBox>
           </S.ImgContainer>
         </S.Section>
-        <S.Section flexdirection="row-reverse">
+        <S.Section $flexirection="row-reverse">
           <S.DescriptionDiv>
             <S.PointDiv>Point. 02</S.PointDiv>
             <S.MainH1>

--- a/src/pages/PostMessagePage/PostMessagePage.js
+++ b/src/pages/PostMessagePage/PostMessagePage.js
@@ -14,8 +14,6 @@ export const PostMessagePage = () => {
   const [isName, setIsName] = useState();
   const [selectedRelationOption, setSelectedRelationOption] = useState('지인'); //관계
   const [selectedFontOption, setSelectedFontOption] = useState('Noto Sans'); // 폰트
-  const [selectedFontOptionLabel, setSelectedFontOptionLabel] =
-    useState('Noto Sans'); // 폰트
   const [profileImg, setProfileImg] = useState(); //프로필 사진
   const [editorTextContent, setEditorTextContent] = useState(''); //메세지
   const [passValue, setPassValue] = useState(true); //값 확인
@@ -52,8 +50,8 @@ export const PostMessagePage = () => {
   const dropdownFontOptions = [
     { value: 'Noto Sans', label: 'Noto Sans' },
     { value: 'Pretendard', label: 'Pretendard' },
-    { value: 'NanumMyeongjo', label: '나눔 명조' },
-    { value: 'NanumLetter', label: '나눔손글씨 손편지체' },
+    { value: '나눔명조', label: '나눔명조' },
+    { value: '나눔손글씨 손편지체', label: '나눔손글씨 손편지체' },
   ];
 
   const handleNameChange = (e) => {
@@ -106,9 +104,8 @@ export const PostMessagePage = () => {
     setIsOpen(false); // 드롭다운 닫기
   };
 
-  const handleSelectFont = (font, label) => {
+  const handleSelectFont = (font) => {
     setSelectedFontOption(font);
-    setSelectedFontOptionLabel(label);
     setIsOpenFont(false); // 드롭다운 닫기
   };
 
@@ -149,7 +146,7 @@ export const PostMessagePage = () => {
     <>
       <S.NavController>
         <Header
-          page="main"
+          page="postMeesge"
           style={{
             borderColor: isName ? `${COLORS.ERROR}` : `${COLORS.GRAY_300}`,
           }}
@@ -265,15 +262,13 @@ export const PostMessagePage = () => {
               <S.DropdownIcon src={isOpenFont ? arrowUpIcon : arrowDownIcon} />
 
               <S.PostMessageDropdownListButton>
-                {selectedFontOptionLabel}
+                {selectedFontOption}
               </S.PostMessageDropdownListButton>
               <S.PostMessageDropdownListContent isOpen={isOpenFont}>
                 {dropdownFontOptions.map((DropOption) => (
                   <S.DropdownListContentOption
                     key={DropOption.value}
-                    onClick={() =>
-                      handleSelectFont(DropOption.value, DropOption.label)
-                    }
+                    onClick={() => handleSelectFont(DropOption.value)}
                   >
                     {DropOption.label}
                   </S.DropdownListContentOption>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #56



## 📝 작업 내용

> 헤더의 값을 변경하고 폰트 값을 서버에 맞게 재조정했습니다.


## 📸 스크린샷 
![메세지 구현3](https://github.com/part2-11team/rolling-paper/assets/94046941/1bed05f7-dc6b-4e82-ac62-fc60a2d47839)


## 💬 리뷰 요구사항

>  불필요한 코드를 제거하였습니다.
> 폰트 값을 수정했습니다.

